### PR TITLE
Generalize upgrades between different major versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
+  - pip install setuptools --upgrade
   - pip install -r requirements.txt
-  - pip install coveralls
+  - pip install coveralls flake8
 script:
   - python setup.py test
   - python setup.py flake8

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 ## Install etcd
-ENV ETCDVERSION 2.3.7
-RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --xform='s/$/v2/x' --strip=1 --wildcards --no-anchored etcd
 
-ENV ETCDVERSION 3.0.17
+ARG ETCDVERSION_PREV=3.0.17
+RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION_PREV}/etcd-v${ETCDVERSION_PREV}-linux-amd64.tar.gz | tar xz -C /bin --xform='s/$/.old/x' --strip=1 --wildcards --no-anchored etcd
+
+ARG ETCDVERSION=3.1.10
+ENV ETCDVERSION=$ETCDVERSION
 RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl
 
 COPY etcd.py /bin/etcd.py

--- a/etcd.py
+++ b/etcd.py
@@ -224,7 +224,7 @@ class EtcdMember:
                                     ToPort=self.peer_port,
                                     CidrIp='{}/32'.format(m.addr)
                                 )
-                            except:
+                            except Exception:
                                 logging.exception('Exception on %s for for %s', action, m.addr)
 
     def add_member(self, member):
@@ -318,7 +318,7 @@ class EtcdCluster:
                         self.leader_id = member.get_leader()  # Let's ask him about leader of etcd-cluster
                         self.cluster_version = member.get_cluster_version()  # and about cluster-wide etcd version
                         break
-                except:
+                except Exception:
                     logging.exception('Load members from etcd')
 
         # combine both lists together
@@ -413,7 +413,7 @@ class EtcdManager:
                 os.remove(path)
             elif os.path.isdir(path):
                 shutil.rmtree(path)
-        except:
+        except Exception:
             logging.exception('Can not remove %s', path)
 
     def register_me(self, cluster):
@@ -478,7 +478,7 @@ class EtcdManager:
                     self.etcd_pid = 0
             except SystemExit:
                 break
-            except:
+            except Exception:
                 logging.exception('Exception in main loop')
             logging.warning('Sleeping %s seconds before next try...', self.NAPTIME)
             time.sleep(self.NAPTIME)
@@ -614,7 +614,7 @@ class HouseKeeper(Thread):
                                 break
                         else:
                             logging.error('upgrade: giving up...')
-            except:
+            except Exception:
                 logging.exception('Exception in HouseKeeper main loop')
             logging.debug('Sleeping %s seconds...', self.NAPTIME)
             time.sleep(self.NAPTIME)
@@ -653,7 +653,7 @@ def main():
                     logging.error('Can not remove myself from cluster')
             else:
                 logging.error('Cluster does not have accessible member')
-        except:
+        except Exception:
             logging.exception('Failed to remove myself from cluster')
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ NAME = 'stups-etcd-cluster'
 VERSION = '1.0'
 DESCRIPTION = 'Etcd cluster appliance for the STUPS (AWS) environment'
 LICENSE = 'Apache License Version 2.0'
-URL = 'https://github.com/zalando/stups-etcd-cluster'
+URL = 'https://github.com/zalando-stups/stups-etcd-cluster'
 AUTHOR = 'Alexander Kukushkin'
 AUTHOR_EMAIL = 'alexander.kukushkin@zalando.de'
 KEYWORDS = 'etcd cluster etcd-cluster stups aws'
@@ -33,8 +33,9 @@ CLASSIFIERS = [
     'Operating System :: POSIX :: Linux',
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 
@@ -66,7 +67,7 @@ class PyTest(TestCommand):
     def run_tests(self):
         try:
             import pytest
-        except:
+        except Exception:
             raise RuntimeError('py.test is not installed, run: pip install pytest')
         params = {'args': self.test_args}
         if self.cov:
@@ -117,9 +118,8 @@ def setup_package():
         test_suite='tests',
         packages=[],
         install_requires=get_install_requirements('requirements.txt'),
-        setup_requires=['flake8'],
         cmdclass=cmdclass,
-        tests_require=['pytest-cov', 'pytest', 'mock'],
+        tests_require=['pytest-cov', 'pytest', 'mock', 'flake8'],
         command_options=command_options,
         entry_points={'console_scripts': CONSOLE_SCRIPTS},
     )

--- a/tests/test_etcd_cluster.py
+++ b/tests/test_etcd_cluster.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from etcd import EtcdCluster, EtcdManager, EtcdMember
@@ -18,6 +19,7 @@ class TestEtcdCluster(unittest.TestCase):
         self.cluster = EtcdCluster(self.manager)
         self.cluster.load_members()
         self.assertFalse(EtcdCluster.is_multiregion())
+        os.environ['ETCDVERSION'] = '3.2.10'
 
     @patch('boto3.resource')
     def test_load_members(self, res):

--- a/tests/test_etcd_housekeeper.py
+++ b/tests/test_etcd_housekeeper.py
@@ -91,7 +91,7 @@ class TestHouseKeeper(unittest.TestCase):
         self.assertRaises(Exception, self.keeper.run)
         with patch('time.sleep', Mock()):
             self.keeper.is_leader = Mock(return_value=False)
-            self.keeper.manager.runv2 = True
+            self.keeper.manager.run_old = True
             self.keeper.cluster_unhealthy = Mock(side_effect=[False, True, False])
             self.assertRaises(Exception, self.keeper.run)
             self.keeper.cluster_unhealthy = Mock(side_effect=[False] + [True]*100)


### PR DESCRIPTION
And support building of new docker images without updating Dockerfile:

```
$ docker build --build-arg ETCDVERSION_PREV=2.3.8 --build-arg ETCDVERSION=3.0.17 -t etcd-cluster:3.1.11-p18 .
$ docker build --build-arg ETCDVERSION_PREV=3.0.17 --build-arg ETCDVERSION=3.1.11 -t etcd-cluster:3.1.11-p18 .
$ docker build --build-arg ETCDVERSION_PREV=3.1.11 --build-arg ETCDVERSION=3.2.11 -t etcd-cluster:3.2.11-p18 .
```