### PR TITLE
Serve metrics under a dedicated port

### DIFF
--- a/etcd.py
+++ b/etcd.py
@@ -37,6 +37,7 @@ class EtcdMember:
     API_VERSION = '/v2/'
     DEFAULT_CLIENT_PORT = 2379
     DEFAULT_PEER_PORT = 2380
+    DEFAULT_METRICS_PORT = 2381
     AG_TAG = 'aws:autoscaling:groupName'
     CF_TAG = 'aws:cloudformation:stack-name'
 
@@ -56,6 +57,7 @@ class EtcdMember:
 
         self.client_port = self.DEFAULT_CLIENT_PORT
         self.peer_port = self.DEFAULT_PEER_PORT
+        self.metrics_port = self.DEFAULT_METRICS_PORT
 
         self.client_urls = []  # these values could be assigned only from the running etcd
         self.peer_urls = []  # cluster by performing http://addr:client_port/v2/members api call
@@ -253,6 +255,8 @@ class EtcdMember:
             self.peer_url,
             '-listen-client-urls',
             'http://0.0.0.0:{}'.format(self.client_port),
+            '-listen-metrics-urls',
+            'http://0.0.0.0:{}'.format(self.metrics_port),
             '-advertise-client-urls',
             self.get_client_url(),
             '-initial-cluster',

--- a/etcd.py
+++ b/etcd.py
@@ -243,7 +243,7 @@ class EtcdMember:
         self.adjust_security_groups('revoke_ingress', member)
         return result
 
-    def etcd_arguments(self, data_dir, initial_cluster, cluster_state):
+    def etcd_arguments(self, data_dir, initial_cluster, cluster_state, run_old)):
         # common flags that always have to be set
         arguments = [
             '-name',
@@ -267,7 +267,7 @@ class EtcdMember:
         ]
 
         # this section handles etcd version specific flags
-        etcdversion = os.environ.get('ETCDVERSION')
+        etcdversion = os.environ.get('ETCDVERSION_PREV' if run_old else 'ETCDVERSION')
         if etcdversion:
             etcdversion = tuple(int(x) for x in etcdversion.split('.'))
             # etcd >= v3.3: serve metrics on an additonal port
@@ -471,7 +471,7 @@ class EtcdManager:
         peers = ','.join(['{}={}'.format(m.instance_id or m.name, m.peer_url) for m in cluster.members
                          if (include_ec2_instances and m.instance_id) or m.peer_urls])
 
-        return self.me.etcd_arguments(self.DATA_DIR, peers, cluster_state)
+        return self.me.etcd_arguments(self.DATA_DIR, peers, cluster_state, self.run_old)
 
     def run(self):
         cluster = EtcdCluster(self)

--- a/etcd.py
+++ b/etcd.py
@@ -243,7 +243,7 @@ class EtcdMember:
         self.adjust_security_groups('revoke_ingress', member)
         return result
 
-    def etcd_arguments(self, data_dir, initial_cluster, cluster_state, run_old)):
+    def etcd_arguments(self, data_dir, initial_cluster, cluster_state, run_old):
         # common flags that always have to be set
         arguments = [
             '-name',

--- a/etcd.py
+++ b/etcd.py
@@ -269,15 +269,13 @@ class EtcdMember:
         # this section handles etcd version specific flags
         etcdversion = os.environ.get('ETCDVERSION')
         if etcdversion:
-            etcdversion = list(map(lambda x: int(x), etcdversion.split('.')))
-            # don't try to add additonal flags if we encounter an unexpected version format
-            if len(etcdversion) == 3:
-                # etcd >= v3.3: serve metrics on an additonal port
-                if etcdversion[0] >= 3 and etcdversion[1] >= 3:
-                    arguments += [
-                        '-listen-metrics-urls',
-                        'http://0.0.0.0:{}'.format(self.metrics_port),
-                    ]
+            etcdversion = tuple(int(x) for x in etcdversion.split('.'))
+            # etcd >= v3.3: serve metrics on an additonal port
+            if etcdversion >= (3, 3):
+                arguments += [
+                    '-listen-metrics-urls',
+                    'http://0.0.0.0:{}'.format(self.metrics_port),
+                ]
 
         # return final list of arguments
         return arguments


### PR DESCRIPTION
etcd v3.3 introduced a new flag to allow serving `/metrics` and `/health` under a different port than e.g. `/v2/keys`. This allows us to protect etcd's data via firewall rules but still let monitoring tools to access the monitoring information.

See feature request in etcd repo: https://github.com/coreos/etcd/issues/8060.
The implementation landed in v3.3: https://github.com/coreos/etcd/pull/8242

This PR instructs etcd to serve metrics and health under the additonal port `2381` *unconditionally* **when the used etcd binary is** `>=v3.3.x`. However, if not explicitely set in the `senza.yaml` this port won't be mapped to the outside and therefore isn't accessible. It doesn't expose more information than anything under `2379` already does. See our intended usage here: https://github.com/zalando-incubator/kubernetes-on-aws/pull/879.

Note: ~~This fails when bundled with etcd lower than `v3.3`~~. Furthermore, serving this additional endpoint unconditionally should be safe but might not be desired. It keeps the implementation very simple, though. LMKWYT

/cc @CyberDem0n @aermakov-zalando @mikkeloscar 