### PR TITLE
Update etcd repository url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 ## Install etcd
 
 ARG ETCDVERSION_PREV=3.2.20
-RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION_PREV}/etcd-v${ETCDVERSION_PREV}-linux-amd64.tar.gz \
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/v${ETCDVERSION_PREV}/etcd-v${ETCDVERSION_PREV}-linux-amd64.tar.gz \
         | tar xz -C /bin --xform='s/$/.old/x' --strip=1 --wildcards --no-anchored etcd \
     && chown root:root /bin/etcd.old \
     && chmod +x /bin/etcd.old
 
 ARG ETCDVERSION=3.3.5
 ENV ETCDVERSION=$ETCDVERSION
-RUN curl -L https://github.com/coreos/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/v${ETCDVERSION}/etcd-v${ETCDVERSION}-linux-amd64.tar.gz \
         | tar xz -C /bin --strip=1 --wildcards --no-anchored etcd etcdctl \
     && chown root:root /bin/etcd /bin/etcdctl \
     && chmod +x /bin/etcd /bin/etcdctl

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -5,9 +5,6 @@ build_steps:
         apt-get install -y python3 python3-pip jq
         pip3 install scm-source
 
-    - desc: Install Docker
-      cmd: 'curl -sSL https://get.docker.com/ | sh'
-
     - desc: scm-source file create
       cmd: |
         scm-source
@@ -15,10 +12,10 @@ build_steps:
     - desc: Build and push docker images
       cmd: |
         # Please bump PATCH_VERSION if you change etcd.py or Dockerfile
-        PATCH_VERSION=p21
+        PATCH_VERSION=p22
         STOP_VERSION=2.3
 
-        ETCD_VERSIONS=$(curl -sL "https://api.github.com/repos/coreos/etcd/releases?per_page=100" | jq -r .[].name | sed -n 's/^v\([^-]*\)$/\1/p' | sort -urV)
+        ETCD_VERSIONS=$(curl -sL "https://api.github.com/repos/etcd-io/etcd/releases?per_page=100" | jq -r .[].name | sed -n 's/^v\([^-]*\)$/\1/p' | sort -urV)
         ETCD_MAJOR_VERSIONS=$(sed 's/\.[0-9]*$//g' <<< "$ETCD_VERSIONS" | sort -urV)
 
         for major_version in $ETCD_MAJOR_VERSIONS; do


### PR DESCRIPTION
The repo was renamed from `coreos/etcd` to `etcd-io/etcd`